### PR TITLE
Issue #6: Fix ping scan results not showing complete list of hosts

### DIFF
--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -92,7 +92,7 @@ class Nmap(object):
 
     def nmap_dns_brute_script(self, host, dns_brute="--script dns-brute.nse"):
         """
-        Perform nmap scan usign the dns-brute script
+        Perform nmap scan using the dns-brute script
 
         :param: host can be IP or domain
         :param: default is the default top port

--- a/nmap3/nmapparser.py
+++ b/nmap3/nmapparser.py
@@ -114,29 +114,30 @@ class NmapCommandParser(object):
         Performs parsing for nmap pingscan xml rests
         @ return DICT
         """
-        ping_status = dict()
+        ping_status_list = []
         try:
             
             if not xml_root:
                 return host_list
             self.xml_root == xml_root
-            host = xml_root.find("host")
             
-            if(host):
-                ping_status = host.find('status').attrib
-                address = []
-                hostname = []
-                
-                for addr in host.findall("address"):
-                    address.append(addr.attrib)
-                ping_status["addresses"]=address
-                
-                if(host.find("hostnames")):
-                    for host_n in host.find("hostnames").findall("hostname"):
-                        hostname.append(host_n.attrib)
-                ping_status["hostname"]=hostname
-                
-            return ping_status
+            for host in xml_root.findall("host"):
+                host_ping_status = dict()
+                if(host):
+                    host_ping_status = host.find('status').attrib
+                    address = []
+                    hostname = []
+                    
+                    for addr in host.findall("address"):
+                        address.append(addr.attrib)
+                    host_ping_status["addresses"]=address
+                    
+                    if(host.find("hostnames")):
+                        for host_n in host.find("hostnames").findall("hostname"):
+                            hostname.append(host_n.attrib)
+                    host_ping_status["hostname"]=hostname
+                ping_status_list.append(host_ping_status)
+            return ping_status_list
         except Exception as e:
             raise
             


### PR DESCRIPTION
This is a fix for `parse_nmap_pingscan()` that only returns the first host in the response. It replaces `find` with `findall` to iterate through all hosts in the xml response and returns a list of host results.

This is a breaking change because it changes the return type of the `parse_nmap_pingscan()` function