### PR TITLE
implement Nmap version detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ version_result = nmap.nmap_version_detection("your-host.com")
 ### Nmap commands available
 The following nmaps commands have been added to the following scripts
 
+ - get Nmap version details
+   ```python
+   import nmap3
+   nmap = nmap3.Nmap()
+   results = nmap.nmap_version()
+   ```
  - Nmap top port scan
    ```python
    import nmap3

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -64,6 +64,28 @@ class Nmap(object):
         """
         return self.default_args.format(nmap=self.nmaptool, outarg="-oX")
 
+    def nmap_version(self):
+        """
+        Returns nmap version and build details
+        """
+        # nmap version output is not available in XML format (eg. -oX -)
+        output = self.run_command([self.nmaptool, '--version'])
+        version_data = {}
+        for line in output.splitlines():
+            if line.startswith('Nmap version '):
+                version_string = line.split(' ')[2]
+                version_data['nmap'] = tuple([int(_) for _ in version_string.split('.')])
+            elif line.startswith('Compiled with:'):
+                compiled_with = line.split(':')[1].strip()
+                version_data['compiled_with'] = tuple(compiled_with.split(' '))
+            elif line.startswith('Compiled without:'):
+                compiled_without = line.split(':')[1].strip()
+                version_data['compiled_without'] = tuple(compiled_without.split(' '))
+            elif line.startswith('Available nsock engines:'):
+                nsock_engines = line.split(':')[1].strip()
+                version_data['nsock_engines'] = tuple(nsock_engines.split(' '))
+        return version_data
+
 # Unique method for repetitive tasks - Use of 'target' variable instead of 'host' or 'subnet' - no need to make difference between 2 strings that are used for the same purpose
     def scan_command(self, target, arg, args):
         self.target == target


### PR DESCRIPTION
This is a little patch to add the ability to get Nmap version data already parsed out, it is useful when there is a need to verify minimum Nmap version requirements or if a specific feature has been compiled in.

```python
>>> # get all details
>>> nmap3.Nmap().nmap_version()
{'compiled_with': ('nmap-liblua-5.3.5',
                   'openssl-1.1.1d',
                   'nmap-libssh2-1.8.2',
                   'libz-1.2.11',
                   'libpcre-8.44',
                   'libpcap-1.9.1',
                   'nmap-libdnet-1.12',
                   'ipv6'),
 'compiled_without': ('',),
 'nmap': (7, 80),
 'nsock_engines': ('kqueue', 'poll', 'select')}

>>> # check version requirements
>>> nmap3.Nmap().nmap_version()['nmap'] >= (7,1)
True
>>> nmap3.Nmap().nmap_version()['nmap'] < (8,0)
True
```