### PR TITLE
Feature/progress callback (thread safe.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,9 +102,3 @@ venv.bak/
 
 # mypy
 .mypy_cache/
-
-# Ignore all files in tmp/
-tmp/*
-
-# But do not ignore the placeholder file, so Git keeps the directory
-!tmp/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,9 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Ignore all files in tmp/
+tmp/*
+
+# But do not ignore the placeholder file, so Git keeps the directory
+!tmp/.gitkeep

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -42,6 +42,7 @@ class Nmap(object):
     This nmap class allows us to use the nmap port scanner tool from within python
     by calling nmap3.Nmap()
     """
+    _id_counter = 0 # class-level counter used to compute unique IDs. shared across all instances of class
 
     def __init__(self, path:str=''):
         """
@@ -49,7 +50,7 @@ class Nmap(object):
 
         :param path: Path where nmap is installed on a user system. On linux system it's typically on /usr/bin/nmap.
         """
-
+        self._set_uid() #set self.id
         self.nmaptool = get_nmap_path(path) # check path, search or raise error
         self.default_args = "{nmap}  {outarg}  -  "
         self.maxport = 65535
@@ -58,6 +59,14 @@ class Nmap(object):
         self.parser = NmapCommandParser(None)
         self.raw_output = None
         self.as_root = False
+
+    def _set_uid(self):
+        """
+        Assign a unique string ID to this instance using a class-level counter.
+        """
+        type(self)._id_counter += 1 #inc class-level counter
+        self.id = type(self)._id_counter #get UID for class instance
+        self.id = str(self.id)
 
     def require_root(self, required=True):
         """

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -274,6 +274,7 @@ class Nmap(object):
         )
         """
 
+        xml_path = None
         if progress_callback:
             #get file to store xml output if progress_callback is used
             with tempfile.NamedTemporaryFile(mode="w+", suffix=".xml", delete=False) as tmp:
@@ -311,7 +312,8 @@ class Nmap(object):
             sub_proc.kill()
             raise (e)
         finally:
-            os.remove(xml_path)
+            if(xml_path):
+                os.remove(xml_path)
 
         if 0 != sub_proc.returncode:
             raise NmapExecutionError(

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -125,7 +125,7 @@ class Nmap(object):
         return version_data
 
     # Unique method for repetitive tasks - Use of 'target' variable instead of 'host' or 'subnet' - no need to make difference between 2 strings that are used for the same purpose
-    def scan_command(self, target, arg, args=None, timeout=None):
+    def scan_command(self, target, arg, args=None, timeout=None, progress_callback=None):
         self.target = target
 
         command_args = "{target}  {default}".format(target=target, default=arg)
@@ -134,7 +134,7 @@ class Nmap(object):
             scancommand += " {0}".format(args)
 
         scan_shlex = shlex.split(scancommand)
-        output = self.run_command(scan_shlex, timeout=timeout)
+        output = self.run_command(scan_shlex, timeout=timeout, progress_callback=progress_callback)
         file_name=re.search(r'(\-oX|-oN-|oG)\s+[a-zA-Z-_0-9]{1,100}\.[a-zA-Z]+',scancommand)
         if file_name:
             file_name=scancommand[file_name.start():file_name.end()].split(" ")[0]
@@ -215,42 +215,42 @@ class Nmap(object):
 
     # Using of basic options for stealth scan
     @user_is_root
-    def nmap_stealth_scan(self, target, arg="-Pn -sZ", args=None):
+    def nmap_stealth_scan(self, target, arg="-Pn -sZ", args=None, progress_callback=None):
         """
         nmap -oX - nmmapper.com -Pn -sZ
         """
-        xml_root = self.scan_command(target=target, arg=arg, args=args)
+        xml_root = self.scan_command(target=target, arg=arg, args=args, progress_callback=None)
         self.top_ports = self.parser.filter_top_ports(xml_root)
         return self.top_ports
 
-    def nmap_detect_firewall(self, target, arg="-sA", args=None):  # requires root
+    def nmap_detect_firewall(self, target, arg="-sA", args=None, progress_callback=None):  # requires root
         """
         nmap -oX - nmmapper.com -sA
         @ TODO
         """
-        return self.scan_command(target=target, arg=arg, args=args)
+        return self.scan_command(target=target, arg=arg, args=args, progress_callback=progress_callback)
         # TODO
 
     @user_is_root
-    def nmap_os_detection(self, target, arg="-O", args=None):  # requires root
+    def nmap_os_detection(self, target, arg="-O", args=None, progress_callback=None):  # requires root
         """
         nmap -oX - nmmapper.com -O
         NOTE: Requires root
         """
-        xml_root = self.scan_command(target=target, arg=arg, args=args)
+        xml_root = self.scan_command(target=target, arg=arg, args=args, progress_callback=progress_callback)
         results = self.parser.os_identifier_parser(xml_root)
         return results
 
-    def nmap_subnet_scan(self, target, arg="-p-", args=None):  # requires root
+    def nmap_subnet_scan(self, target, arg="-p-", args=None, progress_callback=None):  # requires root
         """
         nmap -oX - nmmapper.com -p-
         NOTE: Requires root
         """
-        xml_root = self.scan_command(target=target, arg=arg, args=args)
+        xml_root = self.scan_command(target=target, arg=arg, args=args, progress_callback=progress_callback)
         results = self.parser.filter_top_ports(xml_root)
         return results
 
-    def nmap_list_scan(self, target, arg="-sL", args=None):  # requires root
+    def nmap_list_scan(self, target, arg="-sL", args=None, progress_callback=None):  # requires root
         """
         The list scan is a degenerate form of target discovery that simply lists each target of the network(s)
         specified, without sending any packets to the target targets.
@@ -258,7 +258,7 @@ class Nmap(object):
         NOTE: /usr/bin/nmap  -oX  -  192.168.178.1/24  -sL
         """
         self.target = target
-        xml_root = self.scan_command(target=target, arg=arg, args=args)
+        xml_root = self.scan_command(target=target, arg=arg, args=args, progress_callback=progress_callback)
         results = self.parser.filter_top_ports(xml_root)
         return results
 
@@ -325,7 +325,7 @@ class Nmap(object):
         finally:
             # Always restore terminal state, even if error/timeout
             term_state.restore()
-            
+
         if 0 != sub_proc.returncode:
             raise NmapExecutionError(
                     'Error during command: "' + ' '.join(cmd) + '"\n\n' \

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -42,7 +42,9 @@ class Nmap(object):
     This nmap class allows us to use the nmap port scanner tool from within python
     by calling nmap3.Nmap()
     """
-    _id_counter = 0 # class-level counter used to compute unique IDs. shared across all instances of class
+    _id_counter = 0 # class-level counter used to compute unique IDs.
+                    # shared across all instances of class.
+                    # Do not alter or read outside _set_uid function
 
     def __init__(self, path:str=''):
         """
@@ -62,7 +64,7 @@ class Nmap(object):
 
     def _set_uid(self):
         """
-        Assign a unique string ID to this instance using a class-level counter.
+        Assign a unique ID to this instance using a class-level counter.
         """
         type(self)._id_counter += 1 #inc class-level counter
         self.id = type(self)._id_counter #get UID for class instance

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -49,10 +49,8 @@ class Nmap(object):
     def __init__(self, path:str=''):
         """
         Module initialization
-
         :param path: Path where nmap is installed on a user system. On linux system it's typically on /usr/bin/nmap.
         """
-        
         self.nmaptool = get_nmap_path(path) # check path, search or raise error
         self.default_args = "{nmap}  {outarg}  -  "
         self.maxport = 65535

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -247,12 +247,30 @@ class Nmap(object):
         results = self.parser.filter_top_ports(xml_root)
         return results
 
-    def run_command(self, cmd, timeout=None, progress_callback=None):
+    def run_command(self, cmd: list[str], timeout: int | None = None, progress_callback: callable[[float], None] | None = None):
         """
-        Runs the nmap command using popen
+        Runs the nmap command using popen.
 
-        @param: cmd--> the command we want run eg /usr/bin/nmap -oX -  nmmapper.com --top-ports 10
-        @param: timeout--> command subprocess timeout in seconds.
+        Parameters
+        ----------
+        cmd : list[str]
+            The command to run, e.g. ['/usr/bin/nmap', '-oX', '-', 'nmmapper.com', '--top-ports', '10'].
+        timeout : int | None
+            Timeout in seconds for the subprocess. If None, waits until finished.
+        progress_callback : callable[[float], None] | None
+            Optional callback function called with the current scan progress (0.0–100.0).
+
+        Example
+        -------
+        def my_progress_callback(progress: float):
+            print(f"Scan progress: {progress:.2f}%")
+
+        nmap = Nmap()
+        nmap.run_command(
+            cmd=["/usr/bin/nmap", "-oX", "-", "example.com", "--top-ports", "10"],
+            timeout=60,
+            progress_callback=my_progress_callback
+        )
         """
         if "--stats-every" not in cmd:
             cmd += ["--stats-every", "1s"]

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -27,7 +27,7 @@ import asyncio
 from xml.etree import ElementTree as ET
 from xml.etree.ElementTree import ParseError
 from nmap3.nmapparser import NmapCommandParser
-from nmap3.utils import get_nmap_path, user_is_root, read_xml_file, communicate_with_progress
+from nmap3.utils import get_nmap_path, user_is_root, read_xml_file, communicate_with_progress, TerminalState
 from nmap3.exceptions import NmapXMLParserError, NmapExecutionError
 import re
 import os
@@ -298,6 +298,10 @@ class Nmap(object):
             else:
                 cmd += ["-oX", self.xml_path]
 
+        #save terminal state incase sub_proc wrecks out terminal on exception
+        term_state = TerminalState()
+        term_state.save()
+
         sub_proc = subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE,
@@ -318,13 +322,16 @@ class Nmap(object):
         except Exception as e:
             sub_proc.kill()
             raise (e)
-        else:
-            if 0 != sub_proc.returncode:
-                raise NmapExecutionError(
-                        'Error during command: "' + ' '.join(cmd) + '"\n\n' \
-                        + errs
-                        )
-            return output
+        finally:
+            # Always restore terminal state, even if error/timeout
+            term_state.restore()
+            
+        if 0 != sub_proc.returncode:
+            raise NmapExecutionError(
+                    'Error during command: "' + ' '.join(cmd) + '"\n\n' \
+                    + errs
+                    )
+        return output
 
     def get_xml_et(self, command_output):
         """

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -175,7 +175,7 @@ class Nmap(object):
         self.top_ports = self.parser.filter_top_ports(xml_root)
         return self.top_ports
 
-    def nmap_dns_brute_script(self, target, dns_brute="--script dns-brute.nse", args=None, timeout=None):
+    def nmap_dns_brute_script(self, target, dns_brute="--script dns-brute.nse", args=None, timeout=None, progress_callback=None):
         """
         Perform nmap scan using the dns-brute script
 
@@ -194,7 +194,7 @@ class Nmap(object):
         dns_brute_shlex = shlex.split(dns_brute_command)  # prepare it for popen
 
         # Run the command and get the output
-        output = self.run_command(dns_brute_shlex, timeout=timeout)
+        output = self.run_command(dns_brute_shlex, timeout=timeout, progress_callback=progress_callback)
 
         # Begin parsing the xml response
         xml_root = self.get_xml_et(output)
@@ -382,7 +382,7 @@ class NmapScanTechniques(Nmap):
         self.parser = NmapCommandParser(None)
 
     # Unique method for repetitive tasks - Use of 'target' variable instead of 'host' or 'subnet' - no need to make difference between 2 strings that are used for the same purpose. Creating a scan template as a switcher
-    def scan_command(self, scan_type, target, args, timeout=None):
+    def scan_command(self, scan_type, target, args, timeout=None, progress_callback=None):
         def tpl(i):
             scan_template = {
                 1: self.fin_scan,
@@ -407,7 +407,7 @@ class NmapScanTechniques(Nmap):
                 scan_shlex = shlex.split(scan_type_command)
 
                 # Use the ping scan parser
-                output = self.run_command(scan_shlex, timeout=timeout)
+                output = self.run_command(scan_shlex, timeout=timeout, progress_callback=progress_callback)
                 xml_root = self.get_xml_et(output)
 
                 return xml_root
@@ -415,30 +415,30 @@ class NmapScanTechniques(Nmap):
             
 
     @user_is_root
-    def nmap_fin_scan(self, target, args=None):
+    def nmap_fin_scan(self, target, args=None, progress_callback=None):
         """
         Perform scan using nmap's fin scan
 
         @cmd nmap -sF 192.168.178.1
 
         """
-        xml_root = self.scan_command(self.fin_scan, target=target, args=args)
+        xml_root = self.scan_command(self.fin_scan, target=target, args=args, progress_callback=progress_callback)
         results = self.parser.filter_top_ports(xml_root)
         return results
     
     @user_is_root
-    def nmap_syn_scan(self, target, args=None):
+    def nmap_syn_scan(self, target, args=None, progress_callback=None):
         """
         Perform syn scan on this given
         target
 
         @cmd nmap -sS 192.168.178.1
         """
-        xml_root = self.scan_command(self.sync_scan, target=target, args=args)
+        xml_root = self.scan_command(self.sync_scan, target=target, args=args, progress_callback=progress_callback)
         results = self.parser.filter_top_ports(xml_root)
         return results
 
-    def nmap_tcp_scan(self, target, args=None):
+    def nmap_tcp_scan(self, target, args=None, progress_callback=None):
         """
         Scan target using the nmap tcp connect
 
@@ -446,12 +446,12 @@ class NmapScanTechniques(Nmap):
         """
         if (args):
             assert (isinstance(args, str)), "Expected string got {0} instead".format(type(args))
-        xml_root = self.scan_command(self.tcp_connt, target=target, args=args)
+        xml_root = self.scan_command(self.tcp_connt, target=target, args=args, progress_callback=progress_callback)
         results = self.parser.filter_top_ports(xml_root)
         return results
     
     @user_is_root
-    def nmap_udp_scan(self, target, args=None):
+    def nmap_udp_scan(self, target, args=None, progress_callback=None):
         """
         Scan target using the nmap tcp connect
 
@@ -460,37 +460,37 @@ class NmapScanTechniques(Nmap):
 
         if (args):
             assert (isinstance(args, str)), "Expected string got {0} instead".format(type(args))
-        xml_root = self.scan_command(self.udp_scan, target=target, args=args)
+        xml_root = self.scan_command(self.udp_scan, target=target, args=args, progress_callback=progress_callback)
         results = self.parser.filter_top_ports(xml_root)
         return results
 
-    def nmap_ping_scan(self, target, args=None):
+    def nmap_ping_scan(self, target, args=None, progress_callback=None):
         """
         Scan target using nmaps' ping scan
 
         @cmd nmap -sP 192.168.178.1
         """
-        xml_root = self.scan_command(self.ping_scan, target=target, args=args)
+        xml_root = self.scan_command(self.ping_scan, target=target, args=args, progress_callback=progress_callback)
         results = self.parser.filter_top_ports(xml_root)
         return results
 
-    def nmap_idle_scan(self, target, args=None):
+    def nmap_idle_scan(self, target, args=None, progress_callback=None):
         """
         Using nmap idle_scan
 
         @cmd nmap -sL 192.168.178.1
         """
-        xml_root = self.scan_command(self.idle_scan, target=target, args=args)
+        xml_root = self.scan_command(self.idle_scan, target=target, args=args, progress_callback=progress_callback)
         results = self.parser.filter_top_ports(xml_root)
         return results
 
-    def nmap_ip_scan(self, target, args=None):
+    def nmap_ip_scan(self, target, args=None, progress_callback=None):
         """
         Using nmap ip_scan
 
         @cmd nmap -sO 192.168.178.1
         """
-        xml_root = self.scan_command(self.ip_scan, target=target, args=args)
+        xml_root = self.scan_command(self.ip_scan, target=target, args=args, progress_callback=progress_callback)
         results = self.parser.filter_top_ports(xml_root)
         return results
 
@@ -513,7 +513,7 @@ class NmapHostDiscovery(Nmap):
         self.disable_dns = "-n"
         self.parser = NmapCommandParser(None)
 
-    def scan_command(self, scan_type, target, args, timeout=None):
+    def scan_command(self, scan_type, target, args, timeout=None, progress_callback=None):
         def tpl(i):
             scan_template = {
                 1: self.port_scan_only,
@@ -535,23 +535,23 @@ class NmapHostDiscovery(Nmap):
                 scan_shlex = shlex.split(scan_type_command)
 
                 # Use the ping scan parser
-                output = self.run_command(scan_shlex, timeout=timeout)
+                output = self.run_command(scan_shlex, timeout=timeout, progress_callback=progress_callback)
                 xml_root = self.get_xml_et(output)
 
                 return xml_root
         raise Exception("Something went wrong")
 
-    def nmap_portscan_only(self, target, args=None):
+    def nmap_portscan_only(self, target, args=None, progress_callback=None):
         """
         Scan target using the nmap tcp connect
 
         @cmd nmap -Pn 192.168.178.1
         """
-        xml_root = self.scan_command(self.port_scan_only, target=target, args=args)
+        xml_root = self.scan_command(self.port_scan_only, target=target, args=args, progress_callback=progress_callback)
         results = self.parser.filter_top_ports(xml_root)
         return results
 
-    def nmap_no_portscan(self, target, args=None):
+    def nmap_no_portscan(self, target, args=None, progress_callback=None):
         """
         Scan target using the nmap tcp connect
 
@@ -559,29 +559,29 @@ class NmapHostDiscovery(Nmap):
         """
         if (args):
             assert (isinstance(args, str)), "Expected string got {0} instead".format(type(args))
-        xml_root = self.scan_command(self.no_port_scan, target=target, args=args)
+        xml_root = self.scan_command(self.no_port_scan, target=target, args=args, progress_callback=progress_callback)
         results = self.parser.filter_top_ports(xml_root)
         return results
 
-    def nmap_arp_discovery(self, target, args=None):
+    def nmap_arp_discovery(self, target, args=None, progress_callback=None):
         """
         Scan target using the nmap tcp connect
         @cmd nmap -PR 192.168.178.1
         """
         if (args):
             assert (isinstance(args, str)), "Expected string got {0} instead".format(type(args))
-        xml_root = self.scan_command(self.arp_discovery, target=target, args=args)
+        xml_root = self.scan_command(self.arp_discovery, target=target, args=args, progress_callback=progress_callback)
         results = self.parser.filter_top_ports(xml_root)
         return results
 
-    def nmap_disable_dns(self, target, args=None):
+    def nmap_disable_dns(self, target, args=None, progress_callback=None):
         """
         Scan target using the nmap tcp connect
         @cmd nmap -n 192.168.178.1
         """
         if (args):
             assert (isinstance(args, str)), "Expected string got {0} instead".format(type(args))
-        xml_root = self.scan_command(self.disable_dns, target=target, args=args)
+        xml_root = self.scan_command(self.disable_dns, target=target, args=args, progress_callback=progress_callback)
         results = self.parser.filter_top_ports(xml_root)
         return results
 
@@ -612,7 +612,7 @@ class NmapAsync(Nmap):
             # Response is bytes so decode the output and return
             return data.decode('utf8').strip()
     
-    async def scan_command(self, target, arg, args=None, timeout=None):
+    async def scan_command(self, target, arg, args=None, timeout=None, progress_callback=None):
         self.target = target
 
         command_args = "{target}  {default}".format(target=target, default=arg)
@@ -620,7 +620,7 @@ class NmapAsync(Nmap):
         if (args):
             scancommand += " {0}".format(args)
 
-        output = await self.run_command(scancommand, timeout=timeout)
+        output = await self.run_command(scancommand, timeout=timeout, progress_callback=progress_callback)
         xml_root = self.get_xml_et(output)
 
         return xml_root

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -27,7 +27,7 @@ import asyncio
 from xml.etree import ElementTree as ET
 from xml.etree.ElementTree import ParseError
 from nmap3.nmapparser import NmapCommandParser
-from nmap3.utils import get_nmap_path, user_is_root
+from nmap3.utils import get_nmap_path, user_is_root, communicate_with_progress
 from nmap3.exceptions import NmapXMLParserError, NmapExecutionError
 import re
 
@@ -127,7 +127,7 @@ class Nmap(object):
         xml_root = self.get_xml_et(output)
         return xml_root
 
-    def scan_top_ports(self, target, default=10, args=None, timeout=None):
+    def scan_top_ports(self, target, default=10, args=None, timeout=None, progress_callback=None):
         """
         Perform nmap's top ports scan
 
@@ -150,7 +150,7 @@ class Nmap(object):
         scan_shlex = shlex.split(scan_command)
 
         # Run the command and get the output
-        output = self.run_command(scan_shlex, timeout=timeout)
+        output = self.run_command(scan_shlex, timeout=timeout, progress_callback=progress_callback)
         if not output:
             # Probaby and error was raise
             raise ValueError("Unable to perform requested command")
@@ -247,20 +247,29 @@ class Nmap(object):
         results = self.parser.filter_top_ports(xml_root)
         return results
 
-    def run_command(self, cmd, timeout=None):
+    def run_command(self, cmd, timeout=None, progress_callback=None):
         """
         Runs the nmap command using popen
 
         @param: cmd--> the command we want run eg /usr/bin/nmap -oX -  nmmapper.com --top-ports 10
         @param: timeout--> command subprocess timeout in seconds.
         """
+        if "--stats-every" not in cmd:
+            cmd += ["--stats-every", "1s"]
+
+        if "-oX" in cmd: #TODO: replace
+            index = cmd.index("-oX")  # find the position of "-oX"
+            cmd[index+1] = "tmp"
+
         sub_proc = subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                stderr=subprocess.PIPE,
+                text=True
                 )
+
         try:
-            output, errs = sub_proc.communicate(timeout=timeout)
+            output, errs = communicate_with_progress(sub_proc=sub_proc, timeout=timeout, progress_callback=progress_callback)
         except Exception as e:
             sub_proc.kill()
             raise (e)
@@ -268,10 +277,9 @@ class Nmap(object):
             if 0 != sub_proc.returncode:
                 raise NmapExecutionError(
                         'Error during command: "' + ' '.join(cmd) + '"\n\n' \
-                        + errs.decode('utf8')
+                        + errs
                         )
-            # Response is bytes so decode the output and return
-            return output.decode('utf8').strip()
+            return output
             
 
     def get_xml_et(self, command_output):

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -30,6 +30,7 @@ from nmap3.nmapparser import NmapCommandParser
 from nmap3.utils import get_nmap_path, user_is_root, communicate_with_progress
 from nmap3.exceptions import NmapXMLParserError, NmapExecutionError
 import re
+from typing import Callable, Optional
 
 __author__ = 'Wangolo Joel (inquiry@nmapper.com)'
 __version__ = '1.9.3'
@@ -258,7 +259,7 @@ class Nmap(object):
         results = self.parser.filter_top_ports(xml_root)
         return results
 
-    def run_command(self, cmd: list[str], timeout: int | None = None, progress_callback: callable[[float], None] | None = None):
+    def run_command(self, cmd: list[str], timeout: int | None = None, progress_callback: Optional[Callable[[float], None]] | None = None):
         """
         Runs the nmap command using popen.
 

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -27,13 +27,12 @@ import asyncio
 from xml.etree import ElementTree as ET
 from xml.etree.ElementTree import ParseError
 from nmap3.nmapparser import NmapCommandParser
-from nmap3.utils import get_nmap_path, user_is_root, communicate_with_progress, TerminalState
+from nmap3.utils import get_nmap_path, user_is_root, communicate_with_progress
 from nmap3.exceptions import NmapXMLParserError, NmapExecutionError
 import re
-import os
 from typing import Callable, Optional
 import tempfile
-import atexit
+import os
 
 __author__ = 'Wangolo Joel (inquiry@nmapper.com)'
 __version__ = '1.9.3'
@@ -60,22 +59,6 @@ class Nmap(object):
         self.parser = NmapCommandParser(None)
         self.raw_output = None
         self.as_root = False
-
-        #get file to store xml output if progress_callback is used
-        with tempfile.NamedTemporaryFile(mode="w+", suffix=".xml", delete=False) as tmp:
-            self.xml_path = tmp.name
-
-        atexit.register(self.cleanup) #always run cleanup on program termination
-
-    def __del__(self):
-        self.cleanup()
-
-    def cleanup(self):
-        """
-        remove the xml file on termination or garbage collection
-        """
-        if os.path.exists(self.xml_path):
-            os.remove(self.xml_path)  
 
     def require_root(self, required=True):
         """
@@ -290,20 +273,22 @@ class Nmap(object):
             progress_callback=my_progress_callback
         )
         """
+
         if progress_callback:
+            #get file to store xml output if progress_callback is used
+            with tempfile.NamedTemporaryFile(mode="w+", suffix=".xml", delete=False) as tmp:
+                xml_path = tmp.name
+
             #tell nmap to print status every 1 second
             if "--stats-every" not in cmd:
                 cmd += ["--stats-every", "1s"]
+
             #tell nmap to write xml to xml_path
             if "-oX" in cmd:
                 index = cmd.index("-oX")
-                cmd[index+1] = self.xml_path
+                cmd[index+1] = xml_path
             else:
-                cmd += ["-oX", self.xml_path]
-
-        #save terminal state in case sub_proc wrecks terminal on exception
-        term_state = TerminalState()
-        term_state.save()
+                cmd += ["-oX", xml_path]
 
         sub_proc = subprocess.Popen(
                 cmd,
@@ -316,7 +301,7 @@ class Nmap(object):
             if(progress_callback):
                 output, errs = communicate_with_progress(
                     sub_proc=sub_proc,
-                    xml_path=self.xml_path,
+                    xml_path=xml_path,
                     timeout=timeout,
                     progress_callback=progress_callback
                 )
@@ -326,8 +311,7 @@ class Nmap(object):
             sub_proc.kill()
             raise (e)
         finally:
-            # Always restore terminal state, even if error/timeout
-            term_state.restore()
+            os.remove(xml_path)
 
         if 0 != sub_proc.returncode:
             raise NmapExecutionError(

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -45,12 +45,14 @@ class Nmap(object):
     This nmap class allows us to use the nmap port scanner tool from within python
     by calling nmap3.Nmap()
     """
+
     def __init__(self, path:str=''):
         """
         Module initialization
 
         :param path: Path where nmap is installed on a user system. On linux system it's typically on /usr/bin/nmap.
         """
+        
         self.nmaptool = get_nmap_path(path) # check path, search or raise error
         self.default_args = "{nmap}  {outarg}  -  "
         self.maxport = 65535

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -53,7 +53,7 @@ class Nmap(object):
 
         :param path: Path where nmap is installed on a user system. On linux system it's typically on /usr/bin/nmap.
         """
-        self._set_uid() #set self.id
+        self.id = self._set_uid() #set self.id
         self.nmaptool = get_nmap_path(path) # check path, search or raise error
         self.default_args = "{nmap}  {outarg}  -  "
         self.maxport = 65535
@@ -62,14 +62,15 @@ class Nmap(object):
         self.parser = NmapCommandParser(None)
         self.raw_output = None
         self.as_root = False
+        self.xml_path = f"tmp/{self.id}.xml"
 
-    def _set_uid(self):
+    def _set_uid(self) -> str:
         """
         Assign a unique ID to this instance using a class-level counter.
         """
         type(self)._id_counter += 1 #inc class-level counter
-        self.id = type(self)._id_counter #get UID for class instance
-        self.id = str(self.id)
+        id = type(self)._id_counter #get UID for class instance
+        return str(id)
 
     def require_root(self, required=True):
         """

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -287,12 +287,16 @@ class Nmap(object):
             progress_callback=my_progress_callback
         )
         """
-        if "--stats-every" not in cmd:
-            cmd += ["--stats-every", "1s"]
-
-        if "-oX" in cmd: #TODO: replace
-            index = cmd.index("-oX")  # find the position of "-oX"
-            cmd[index+1] = self.xml_path
+        if progress_callback:
+            #tell nmap to print status every 1 second
+            if "--stats-every" not in cmd:
+                cmd += ["--stats-every", "1s"]
+            #tell nmap to write xml to xml_path
+            if "-oX" in cmd:
+                index = cmd.index("-oX")
+                cmd[index+1] = self.xml_path
+            else:
+                cmd += ["-oX", self.xml_path]
 
         sub_proc = subprocess.Popen(
                 cmd,
@@ -302,12 +306,15 @@ class Nmap(object):
                 )
 
         try:
-            output, errs = communicate_with_progress(
-                sub_proc=sub_proc,
-                xml_path=self.xml_path,
-                timeout=timeout,
-                progress_callback=progress_callback
-            )
+            if(progress_callback):
+                output, errs = communicate_with_progress(
+                    sub_proc=sub_proc,
+                    xml_path=self.xml_path,
+                    timeout=timeout,
+                    progress_callback=progress_callback
+                )
+            else:
+                output, errs = sub_proc.communicate(timeout=timeout)
         except Exception as e:
             sub_proc.kill()
             raise (e)

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -60,7 +60,6 @@ class Nmap(object):
         self.parser = NmapCommandParser(None)
         self.raw_output = None
         self.as_root = False
-        module_dir = os.path.dirname(__file__)
 
         #get file to store xml output if progress_callback is used
         with tempfile.NamedTemporaryFile(mode="w+", suffix=".xml", delete=False) as tmp:
@@ -302,7 +301,7 @@ class Nmap(object):
             else:
                 cmd += ["-oX", self.xml_path]
 
-        #save terminal state incase sub_proc wrecks out terminal on exception
+        #save terminal state in case sub_proc wrecks terminal on exception
         term_state = TerminalState()
         term_state.save()
 

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -27,10 +27,12 @@ import asyncio
 from xml.etree import ElementTree as ET
 from xml.etree.ElementTree import ParseError
 from nmap3.nmapparser import NmapCommandParser
-from nmap3.utils import get_nmap_path, user_is_root, communicate_with_progress
+from nmap3.utils import get_nmap_path, user_is_root, read_xml_file
 from nmap3.exceptions import NmapXMLParserError, NmapExecutionError
 import re
 from typing import Callable, Optional
+import threading
+import queue
 
 __author__ = 'Wangolo Joel (inquiry@nmapper.com)'
 __version__ = '1.9.3'
@@ -260,6 +262,86 @@ class Nmap(object):
         results = self.parser.filter_top_ports(xml_root)
         return results
 
+    def communicate_with_progress(
+        self,
+        sub_proc: subprocess.Popen,
+        timeout: int = None,
+        progress_callback: Optional[Callable[[float], None]] = None
+    ) -> tuple[str, str]:
+        """
+        Reads stdout and stderr from a subprocess, optionally reporting progress.
+
+        Parameters
+        ----------
+        sub_proc : subprocess.Popen
+            The subprocess object to communicate with.
+        timeout : int | None, optional
+            Timeout in seconds for the subprocess. If None, waits until finished.
+        progress_callback : Callable[[float], None] | None, optional
+            A callback function that is called with the current scan progress
+            as a float between 0.0 and 100.0. Called whenever a line
+            matching "<number>% done" is read from stdout.
+
+        Returns
+        -------
+        Tuple[str, str]
+            A tuple containing the full stdout output and stderr output.
+
+        Example
+        -------
+        def my_progress(progress: float):
+            print(f"Progress: {progress:.2f}%")
+
+        import subprocess
+
+        proc = subprocess.Popen(["/usr/bin/nmap", "-oX", "-", "example.com"],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                text=True)
+        
+        output, errs = communicate_with_progress(proc, timeout=60, progress_callback=my_progress)
+        """
+        stdout_queue = queue.Queue()
+        stderr_queue = queue.Queue()
+
+        def reader(pipe, q):
+            for line in pipe:
+                q.put(line)
+            pipe.close()
+
+        #start threads to read stdout and stderr
+        t_out = threading.Thread(target=reader, args=(sub_proc.stdout, stdout_queue))
+        t_err = threading.Thread(target=reader, args=(sub_proc.stderr, stderr_queue))
+        t_out.start()
+        t_err.start()
+
+        output = ""
+        errs = ""
+
+        while True:
+        
+            if sub_proc.poll() is not None and stdout_queue.empty() and stderr_queue.empty():
+                break #once sub_proc terminates and stdout_queue and stderr_queue are empty we are done
+
+            #Process stdout
+            while not stdout_queue.empty():
+                line = stdout_queue.get_nowait()
+                if progress_callback:
+                    #grab the progress from stdout and pass to progress_callback
+                    match = re.search(r'(\d+(?:\.\d+)?)% done', line)
+                    if match:
+                        progress = float(match.group(1))
+                        progress_callback(progress)
+
+            #Process stderr
+            while not stderr_queue.empty():
+                line = stderr_queue.get_nowait()
+                errs += line
+
+        output = read_xml_file(self.xml_path)
+
+        return output, errs
+
     def run_command(self, cmd: list[str], timeout: int | None = None, progress_callback: Optional[Callable[[float], None]] | None = None):
         """
         Runs the nmap command using popen.
@@ -311,7 +393,6 @@ class Nmap(object):
                         + errs
                         )
             return output
-            
 
     def get_xml_et(self, command_output):
         """

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -27,12 +27,11 @@ import asyncio
 from xml.etree import ElementTree as ET
 from xml.etree.ElementTree import ParseError
 from nmap3.nmapparser import NmapCommandParser
-from nmap3.utils import get_nmap_path, user_is_root, read_xml_file
+from nmap3.utils import get_nmap_path, user_is_root, read_xml_file, communicate_with_progress
 from nmap3.exceptions import NmapXMLParserError, NmapExecutionError
 import re
+import os
 from typing import Callable, Optional
-import threading
-import queue
 
 __author__ = 'Wangolo Joel (inquiry@nmapper.com)'
 __version__ = '1.9.3'
@@ -64,7 +63,8 @@ class Nmap(object):
         self.parser = NmapCommandParser(None)
         self.raw_output = None
         self.as_root = False
-        self.xml_path = f"tmp/{self.id}.xml"
+        module_dir = os.path.dirname(__file__)
+        self.xml_path = os.path.join(module_dir, "tmp", f"{self.id}.xml")
 
     def _set_uid(self) -> str:
         """
@@ -262,86 +262,6 @@ class Nmap(object):
         results = self.parser.filter_top_ports(xml_root)
         return results
 
-    def communicate_with_progress(
-        self,
-        sub_proc: subprocess.Popen,
-        timeout: int = None,
-        progress_callback: Optional[Callable[[float], None]] = None
-    ) -> tuple[str, str]:
-        """
-        Reads stdout and stderr from a subprocess, optionally reporting progress.
-
-        Parameters
-        ----------
-        sub_proc : subprocess.Popen
-            The subprocess object to communicate with.
-        timeout : int | None, optional
-            Timeout in seconds for the subprocess. If None, waits until finished.
-        progress_callback : Callable[[float], None] | None, optional
-            A callback function that is called with the current scan progress
-            as a float between 0.0 and 100.0. Called whenever a line
-            matching "<number>% done" is read from stdout.
-
-        Returns
-        -------
-        Tuple[str, str]
-            A tuple containing the full stdout output and stderr output.
-
-        Example
-        -------
-        def my_progress(progress: float):
-            print(f"Progress: {progress:.2f}%")
-
-        import subprocess
-
-        proc = subprocess.Popen(["/usr/bin/nmap", "-oX", "-", "example.com"],
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE,
-                                text=True)
-        
-        output, errs = communicate_with_progress(proc, timeout=60, progress_callback=my_progress)
-        """
-        stdout_queue = queue.Queue()
-        stderr_queue = queue.Queue()
-
-        def reader(pipe, q):
-            for line in pipe:
-                q.put(line)
-            pipe.close()
-
-        #start threads to read stdout and stderr
-        t_out = threading.Thread(target=reader, args=(sub_proc.stdout, stdout_queue))
-        t_err = threading.Thread(target=reader, args=(sub_proc.stderr, stderr_queue))
-        t_out.start()
-        t_err.start()
-
-        output = ""
-        errs = ""
-
-        while True:
-        
-            if sub_proc.poll() is not None and stdout_queue.empty() and stderr_queue.empty():
-                break #once sub_proc terminates and stdout_queue and stderr_queue are empty we are done
-
-            #Process stdout
-            while not stdout_queue.empty():
-                line = stdout_queue.get_nowait()
-                if progress_callback:
-                    #grab the progress from stdout and pass to progress_callback
-                    match = re.search(r'(\d+(?:\.\d+)?)% done', line)
-                    if match:
-                        progress = float(match.group(1))
-                        progress_callback(progress)
-
-            #Process stderr
-            while not stderr_queue.empty():
-                line = stderr_queue.get_nowait()
-                errs += line
-
-        output = read_xml_file(self.xml_path)
-
-        return output, errs
-
     def run_command(self, cmd: list[str], timeout: int | None = None, progress_callback: Optional[Callable[[float], None]] | None = None):
         """
         Runs the nmap command using popen.
@@ -372,7 +292,7 @@ class Nmap(object):
 
         if "-oX" in cmd: #TODO: replace
             index = cmd.index("-oX")  # find the position of "-oX"
-            cmd[index+1] = "tmp"
+            cmd[index+1] = self.xml_path
 
         sub_proc = subprocess.Popen(
                 cmd,
@@ -382,7 +302,12 @@ class Nmap(object):
                 )
 
         try:
-            output, errs = communicate_with_progress(sub_proc=sub_proc, timeout=timeout, progress_callback=progress_callback)
+            output, errs = communicate_with_progress(
+                sub_proc=sub_proc,
+                xml_path=self.xml_path,
+                timeout=timeout,
+                progress_callback=progress_callback
+            )
         except Exception as e:
             sub_proc.kill()
             raise (e)

--- a/nmap3/nmap3.py
+++ b/nmap3/nmap3.py
@@ -27,11 +27,13 @@ import asyncio
 from xml.etree import ElementTree as ET
 from xml.etree.ElementTree import ParseError
 from nmap3.nmapparser import NmapCommandParser
-from nmap3.utils import get_nmap_path, user_is_root, read_xml_file, communicate_with_progress, TerminalState
+from nmap3.utils import get_nmap_path, user_is_root, communicate_with_progress, TerminalState
 from nmap3.exceptions import NmapXMLParserError, NmapExecutionError
 import re
 import os
 from typing import Callable, Optional
+import tempfile
+import atexit
 
 __author__ = 'Wangolo Joel (inquiry@nmapper.com)'
 __version__ = '1.9.3'
@@ -44,17 +46,12 @@ class Nmap(object):
     This nmap class allows us to use the nmap port scanner tool from within python
     by calling nmap3.Nmap()
     """
-    _id_counter = 0 # class-level counter used to compute unique IDs.
-                    # shared across all instances of class.
-                    # Do not alter or read outside _set_uid function
-
     def __init__(self, path:str=''):
         """
         Module initialization
 
         :param path: Path where nmap is installed on a user system. On linux system it's typically on /usr/bin/nmap.
         """
-        self.id = self._set_uid() #set self.id
         self.nmaptool = get_nmap_path(path) # check path, search or raise error
         self.default_args = "{nmap}  {outarg}  -  "
         self.maxport = 65535
@@ -64,15 +61,22 @@ class Nmap(object):
         self.raw_output = None
         self.as_root = False
         module_dir = os.path.dirname(__file__)
-        self.xml_path = os.path.join(module_dir, "tmp", f"{self.id}.xml")
 
-    def _set_uid(self) -> str:
+        #get file to store xml output if progress_callback is used
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".xml", delete=False) as tmp:
+            self.xml_path = tmp.name
+
+        atexit.register(self.cleanup) #always run cleanup on program termination
+
+    def __del__(self):
+        self.cleanup()
+
+    def cleanup(self):
         """
-        Assign a unique ID to this instance using a class-level counter.
+        remove the xml file on termination or garbage collection
         """
-        type(self)._id_counter += 1 #inc class-level counter
-        id = type(self)._id_counter #get UID for class instance
-        return str(id)
+        if os.path.exists(self.xml_path):
+            os.remove(self.xml_path)  
 
     def require_root(self, required=True):
         """
@@ -262,7 +266,7 @@ class Nmap(object):
         results = self.parser.filter_top_ports(xml_root)
         return results
 
-    def run_command(self, cmd: list[str], timeout: int | None = None, progress_callback: Optional[Callable[[float], None]] | None = None):
+    def run_command(self, cmd: list[str], timeout: int | None = None, progress_callback: Optional[Callable[[str], None]] | None = None):
         """
         Runs the nmap command using popen.
 
@@ -272,13 +276,13 @@ class Nmap(object):
             The command to run, e.g. ['/usr/bin/nmap', '-oX', '-', 'nmmapper.com', '--top-ports', '10'].
         timeout : int | None
             Timeout in seconds for the subprocess. If None, waits until finished.
-        progress_callback : callable[[float], None] | None
-            Optional callback function called with the current scan progress (0.0–100.0).
+        progress_callback : callable[[str], None] | None
+            Optional callback function called with the current scan progress.
 
         Example
         -------
-        def my_progress_callback(progress: float):
-            print(f"Scan progress: {progress:.2f}%")
+        def my_progress_callback(progress: str):
+            print(progress)
 
         nmap = Nmap()
         nmap.run_command(

--- a/nmap3/utils.py
+++ b/nmap3/utils.py
@@ -133,6 +133,7 @@ def communicate_with_progress(
     Tuple[str, str]
         A tuple containing xml and stderr output.
     """
+
     stdout_queue = queue.Queue()
     stderr_queue = queue.Queue()
 
@@ -150,64 +151,39 @@ def communicate_with_progress(
     output = ""
     errs = ""
     start_time = time.time()
-    #save terminal state so it can be restored after exception
-    term_state = TerminalState()
-    term_state.save()
 
-    try:
-        while True:
-        
-            #Check timeout
-            if timeout is not None and (time.time() - start_time) > timeout:
-                sub_proc.kill()
-                errs += f"\nProcess killed after exceeding timeout of {timeout} seconds.\n"
-                break
-
-            if sub_proc.poll() is not None and stdout_queue.empty() and stderr_queue.empty():
-                sub_proc.kill()
-                break # finished
-
-            #Process stdout
-            while not stdout_queue.empty():
-                line = stdout_queue.get_nowait()
-                if progress_callback:
-                    #grab the progress line from stdout and pass to progress_callback
-                    match = re.search(r'(\d+(?:\.\d+)?)% done', line)
-                    if match:
-                        progress_callback(line.strip())
-
-            #Process stderr
-            while not stderr_queue.empty():
-                line = stderr_queue.get_nowait()
-                errs += line
-
-            time.sleep(0.05) # prevent busy-loop
-    finally:
-        if sub_proc.poll() is None:
+    while True:
+    
+        #Check timeout
+        if timeout is not None and (time.time() - start_time) > timeout:
             sub_proc.kill()
-        t_out.join()
-        t_err.join()
-        term_state.restore() #restore terminal state incase sub_proc wrecked our terminal
+            errs += f"\nProcess killed after exceeding timeout of {timeout} seconds.\n"
+            break
 
-    # only parse xml if process wasn't killed
-    if sub_proc.returncode == 0:
-        output = read_then_truncate(xml_path)
+        if sub_proc.poll() is not None and stdout_queue.empty() and stderr_queue.empty():
+            sub_proc.kill()
+            break # finished
+
+        #Process stdout
+        while not stdout_queue.empty():
+            line = stdout_queue.get_nowait()
+            if progress_callback:
+                #grab the progress line from stdout and pass to progress_callback
+                match = re.search(r'(\d+(?:\.\d+)?)% done', line)
+                if match:
+                    progress_callback(line.strip())
+
+        #Process stderr
+        while not stderr_queue.empty():
+            line = stderr_queue.get_nowait()
+            errs += line
+
+        time.sleep(0.05) # prevent busy-loop
+
+    with open(xml_path) as f:
+        output = f.read()
 
     return output, errs
-
-def read_then_truncate(path:str) -> str:
-    """
-    read a file, then seek to begining and truncate.
-    """
-    try:
-        output = ""
-        with open(path, 'r+') as f:
-            output = f.read()
-            f.seek(0)
-            f.truncate()
-        return output
-    except Exception as e:
-        raise e
     
 class TerminalState:
     """

--- a/nmap3/utils.py
+++ b/nmap3/utils.py
@@ -25,6 +25,8 @@ import os
 import ctypes
 import functools
 import re
+import threading
+import queue
 from typing import Optional, Callable
 
 from nmap3.exceptions import NmapNotInstalledError
@@ -103,8 +105,93 @@ def nmap_is_installed_async():
         return wrapped
     return  wrapper 
 
-def read_xml_file(path:str) -> str:
+def communicate_with_progress(
+    sub_proc: subprocess.Popen,
+    xml_path: str,
+    timeout: int = None,
+    progress_callback: Optional[Callable[[float], None]] = None
+) -> tuple[str, str]:
+    """
+    Reads stdout and stderr from a subprocess, optionally reporting progress.
+
+    Parameters
+    ----------
+    sub_proc : subprocess.Popen
+        The subprocess object to communicate with.
+    xml_path : str
+        Path to xml_file for io
+    timeout : int | None, optional
+        Timeout in seconds for the subprocess. If None, waits until finished.
+    progress_callback : Callable[[float], None] | None, optional
+        A callback function that is called with the current scan progress
+        as a float between 0.0 and 100.0. Called whenever a line
+        matching "<number>% done" is read from stdout.
+
+    Returns
+    -------
+    Tuple[str, str]
+        A tuple containing the full stdout output and stderr output.
+
+    Example
+    -------
+    def my_progress(progress: float):
+        print(f"Progress: {progress:.2f}%")
+
+    import subprocess
+
+    proc = subprocess.Popen(["/usr/bin/nmap", "-oX", "-", "example.com"],
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            text=True)
+    
+    output, errs = communicate_with_progress(proc, timeout=60, progress_callback=my_progress)
+    """
+    stdout_queue = queue.Queue()
+    stderr_queue = queue.Queue()
+
+    def reader(pipe, q):
+        for line in pipe:
+            q.put(line)
+        pipe.close()
+
+    #start threads to read stdout and stderr
+    t_out = threading.Thread(target=reader, args=(sub_proc.stdout, stdout_queue))
+    t_err = threading.Thread(target=reader, args=(sub_proc.stderr, stderr_queue))
+    t_out.start()
+    t_err.start()
+
     output = ""
-    with open(path) as f:
-        output = f.read()
-    return output
+    errs = ""
+
+    while True:
+    
+        if sub_proc.poll() is not None and stdout_queue.empty() and stderr_queue.empty():
+            break #once sub_proc terminates and stdout_queue and stderr_queue are empty we are done
+
+        #Process stdout
+        while not stdout_queue.empty():
+            line = stdout_queue.get_nowait()
+            if progress_callback:
+                #grab the progress from stdout and pass to progress_callback
+                match = re.search(r'(\d+(?:\.\d+)?)% done', line)
+                if match:
+                    progress = float(match.group(1))
+                    progress_callback(progress)
+
+        #Process stderr
+        while not stderr_queue.empty():
+            line = stderr_queue.get_nowait()
+            errs += line
+
+    output = read_xml_file(xml_path)
+
+    return output, errs
+
+def read_xml_file(path:str) -> str:
+    try:
+        output = ""
+        with open(path) as f:
+            output = f.read()
+        return output
+    except Exception as e:
+        raise e

--- a/nmap3/utils.py
+++ b/nmap3/utils.py
@@ -24,6 +24,9 @@ import sys
 import os
 import ctypes
 import functools
+import threading
+import queue
+import re
 
 from nmap3.exceptions import NmapNotInstalledError
 
@@ -100,3 +103,46 @@ def nmap_is_installed_async():
                 return {"error":True, "msg":"Nmap has not been install on this system yet!"}
         return wrapped
     return  wrapper 
+
+def communicate_with_progress(sub_proc, timeout=None, progress_callback=None):
+    stdout_queue = queue.Queue()
+    stderr_queue = queue.Queue()
+
+    def reader(pipe, q):
+        for line in pipe:
+            q.put(line)
+        pipe.close()
+
+    #start threads to read stdout and stderr
+    t_out = threading.Thread(target=reader, args=(sub_proc.stdout, stdout_queue))
+    t_err = threading.Thread(target=reader, args=(sub_proc.stderr, stderr_queue))
+    t_out.start()
+    t_err.start()
+
+    output = ""
+    errs = ""
+
+    while True:
+    
+        if sub_proc.poll() is not None and stdout_queue.empty() and stderr_queue.empty():
+            break #once sub_proc terminates and stdout_queue and stderr_queue are empty we are done
+
+        #Process stdout
+        while not stdout_queue.empty():
+            line = stdout_queue.get_nowait()
+            if progress_callback:
+                #grab the progress from stdout and pass to progress_callback
+                match = re.search(r'(\d+(?:\.\d+)?)% done', line)
+                if match:
+                    progress = float(match.group(1))
+                    progress_callback(progress)
+
+        #Process stderr
+        while not stderr_queue.empty():
+            line = stderr_queue.get_nowait()
+            errs += line
+
+    with open("tmp") as f: #TODO: replace
+        output = f.read()
+
+    return output, errs

--- a/nmap3/utils.py
+++ b/nmap3/utils.py
@@ -131,21 +131,7 @@ def communicate_with_progress(
     Returns
     -------
     Tuple[str, str]
-        A tuple containing the full stdout output and stderr output.
-
-    Example
-    -------
-    def my_progress(progress: str):
-        print(progress)
-
-    import subprocess
-
-    proc = subprocess.Popen(["/usr/bin/nmap", "-oX", "-", "example.com"],
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE,
-                            text=True)
-    
-    output, errs = communicate_with_progress(proc, timeout=60, progress_callback=my_progress)
+        A tuple containing xml and stderr output.
     """
     stdout_queue = queue.Queue()
     stderr_queue = queue.Queue()

--- a/nmap3/utils.py
+++ b/nmap3/utils.py
@@ -24,8 +24,6 @@ import sys
 import os
 import ctypes
 import functools
-import threading
-import queue
 import re
 from typing import Optional, Callable
 
@@ -105,82 +103,8 @@ def nmap_is_installed_async():
         return wrapped
     return  wrapper 
 
-def communicate_with_progress(
-    sub_proc: subprocess.Popen,
-    timeout: int = None,
-    progress_callback: Optional[Callable[[float], None]] = None
-) -> tuple[str, str]:
-    """
-    Reads stdout and stderr from a subprocess, optionally reporting progress.
-
-    Parameters
-    ----------
-    sub_proc : subprocess.Popen
-        The subprocess object to communicate with.
-    timeout : int | None, optional
-        Timeout in seconds for the subprocess. If None, waits until finished.
-    progress_callback : Callable[[float], None] | None, optional
-        A callback function that is called with the current scan progress
-        as a float between 0.0 and 100.0. Called whenever a line
-        matching "<number>% done" is read from stdout.
-
-    Returns
-    -------
-    Tuple[str, str]
-        A tuple containing the full stdout output and stderr output.
-
-    Example
-    -------
-    def my_progress(progress: float):
-        print(f"Progress: {progress:.2f}%")
-
-    import subprocess
-
-    proc = subprocess.Popen(["/usr/bin/nmap", "-oX", "-", "example.com"],
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE,
-                            text=True)
-    
-    output, errs = communicate_with_progress(proc, timeout=60, progress_callback=my_progress)
-    """
-    stdout_queue = queue.Queue()
-    stderr_queue = queue.Queue()
-
-    def reader(pipe, q):
-        for line in pipe:
-            q.put(line)
-        pipe.close()
-
-    #start threads to read stdout and stderr
-    t_out = threading.Thread(target=reader, args=(sub_proc.stdout, stdout_queue))
-    t_err = threading.Thread(target=reader, args=(sub_proc.stderr, stderr_queue))
-    t_out.start()
-    t_err.start()
-
+def read_xml_file(path:str) -> str:
     output = ""
-    errs = ""
-
-    while True:
-    
-        if sub_proc.poll() is not None and stdout_queue.empty() and stderr_queue.empty():
-            break #once sub_proc terminates and stdout_queue and stderr_queue are empty we are done
-
-        #Process stdout
-        while not stdout_queue.empty():
-            line = stdout_queue.get_nowait()
-            if progress_callback:
-                #grab the progress from stdout and pass to progress_callback
-                match = re.search(r'(\d+(?:\.\d+)?)% done', line)
-                if match:
-                    progress = float(match.group(1))
-                    progress_callback(progress)
-
-        #Process stderr
-        while not stderr_queue.empty():
-            line = stderr_queue.get_nowait()
-            errs += line
-
-    with open("tmp") as f: #TODO: replace
+    with open(path) as f:
         output = f.read()
-
-    return output, errs
+    return output

--- a/nmap3/utils.py
+++ b/nmap3/utils.py
@@ -28,6 +28,8 @@ import re
 import threading
 import queue
 from typing import Optional, Callable
+import time
+import termios, sys, os
 
 from nmap3.exceptions import NmapNotInstalledError
 
@@ -162,32 +164,50 @@ def communicate_with_progress(
 
     output = ""
     errs = ""
+    start_time = time.time()
+    #save terminal state so it can be restored after exception
+    term_state = TerminalState()
+    term_state.save()
 
-    while True:
-    
-        if sub_proc.poll() is not None and stdout_queue.empty() and stderr_queue.empty():
-            break #once sub_proc terminates and stdout_queue and stderr_queue are empty we are done
+    try:
+        while True:
+        
+            #Check timeout
+            if timeout is not None and (time.time() - start_time) > timeout:
+                sub_proc.kill()
+                errs += f"\nProcess killed after exceeding timeout of {timeout} seconds.\n"
+                break
 
-        #Process stdout
-        while not stdout_queue.empty():
-            line = stdout_queue.get_nowait()
-            if progress_callback:
-                #grab the progress from stdout and pass to progress_callback
-                match = re.search(r'(\d+(?:\.\d+)?)% done', line)
-                if match:
-                    progress = float(match.group(1))
-                    progress_callback(progress)
+            if sub_proc.poll() is not None and stdout_queue.empty() and stderr_queue.empty():
+                sub_proc.kill()
+                break # finished
 
-        #Process stderr
-        while not stderr_queue.empty():
-            line = stderr_queue.get_nowait()
-            errs += line
+            #Process stdout
+            while not stdout_queue.empty():
+                line = stdout_queue.get_nowait()
+                if progress_callback:
+                    #grab the progress from stdout and pass to progress_callback
+                    match = re.search(r'(\d+(?:\.\d+)?)% done', line)
+                    if match:
+                        progress = float(match.group(1))
+                        progress_callback(progress)
 
-    # ensure threads have finished
-    t_out.join()
-    t_err.join()
+            #Process stderr
+            while not stderr_queue.empty():
+                line = stderr_queue.get_nowait()
+                errs += line
 
-    output = read_xml_file(xml_path)
+            time.sleep(0.05) # prevent busy-loop
+    finally:
+        if sub_proc.poll() is None:
+            sub_proc.kill()
+        t_out.join()
+        t_err.join()
+        term_state.restore() #restore terminal state incase sub_proc wrecked our terminal
+
+    # only parse xml if process wasn't killed
+    if sub_proc.returncode == 0:
+        output = read_xml_file(xml_path)
 
     return output, errs
 
@@ -199,3 +219,21 @@ def read_xml_file(path:str) -> str:
         return output
     except Exception as e:
         raise e
+    
+class TerminalState:
+    """
+    class used to save and restore terminal state.
+    """
+    def __init__(self):
+        self.orig_attrs = None
+
+    def save(self):
+        if sys.stdin.isatty():
+            self.orig_attrs = termios.tcgetattr(sys.stdin)
+
+    def restore(self):
+        if self.orig_attrs and sys.stdin.isatty():
+            try:
+                termios.tcsetattr(sys.stdin, termios.TCSADRAIN, self.orig_attrs)
+            except Exception:
+                os.system("stty sane")  # fallback

--- a/nmap3/utils.py
+++ b/nmap3/utils.py
@@ -183,6 +183,10 @@ def communicate_with_progress(
             line = stderr_queue.get_nowait()
             errs += line
 
+    # ensure threads have finished
+    t_out.join()
+    t_err.join()
+
     output = read_xml_file(xml_path)
 
     return output, errs

--- a/nmap3/utils.py
+++ b/nmap3/utils.py
@@ -206,15 +206,20 @@ def communicate_with_progress(
 
     # only parse xml if process wasn't killed
     if sub_proc.returncode == 0:
-        output = read_xml_file(xml_path)
+        output = read_then_truncate(xml_path)
 
     return output, errs
 
-def read_xml_file(path:str) -> str:
+def read_then_truncate(path:str) -> str:
+    """
+    read a file, then seek to begining and truncate.
+    """
     try:
         output = ""
-        with open(path) as f:
+        with open(path, 'r+') as f:
             output = f.read()
+            f.seek(0)
+            f.truncate()
         return output
     except Exception as e:
         raise e

--- a/nmap3/utils.py
+++ b/nmap3/utils.py
@@ -29,7 +29,6 @@ import threading
 import queue
 from typing import Optional, Callable
 import time
-import termios, sys, os
 
 from nmap3.exceptions import NmapNotInstalledError
 
@@ -184,21 +183,3 @@ def communicate_with_progress(
         output = f.read()
 
     return output, errs
-    
-class TerminalState:
-    """
-    class used to save and restore terminal state.
-    """
-    def __init__(self):
-        self.orig_attrs = None
-
-    def save(self):
-        if sys.stdin.isatty():
-            self.orig_attrs = termios.tcgetattr(sys.stdin)
-
-    def restore(self):
-        if self.orig_attrs and sys.stdin.isatty():
-            try:
-                termios.tcsetattr(sys.stdin, termios.TCSADRAIN, self.orig_attrs)
-            except Exception:
-                os.system("stty sane")  # fallback

--- a/nmap3/utils.py
+++ b/nmap3/utils.py
@@ -111,7 +111,7 @@ def communicate_with_progress(
     sub_proc: subprocess.Popen,
     xml_path: str,
     timeout: int = None,
-    progress_callback: Optional[Callable[[float], None]] = None
+    progress_callback: Optional[Callable[[str], None]] = None
 ) -> tuple[str, str]:
     """
     Reads stdout and stderr from a subprocess, optionally reporting progress.
@@ -126,8 +126,7 @@ def communicate_with_progress(
         Timeout in seconds for the subprocess. If None, waits until finished.
     progress_callback : Callable[[float], None] | None, optional
         A callback function that is called with the current scan progress
-        as a float between 0.0 and 100.0. Called whenever a line
-        matching "<number>% done" is read from stdout.
+        and details as a string.
 
     Returns
     -------
@@ -136,8 +135,8 @@ def communicate_with_progress(
 
     Example
     -------
-    def my_progress(progress: float):
-        print(f"Progress: {progress:.2f}%")
+    def my_progress(progress: str):
+        print(progress)
 
     import subprocess
 
@@ -186,11 +185,11 @@ def communicate_with_progress(
             while not stdout_queue.empty():
                 line = stdout_queue.get_nowait()
                 if progress_callback:
-                    #grab the progress from stdout and pass to progress_callback
+                    #grab the progress line from stdout and pass to progress_callback
                     match = re.search(r'(\d+(?:\.\d+)?)% done', line)
                     if match:
-                        progress = float(match.group(1))
-                        progress_callback(progress)
+                        #progress = float(match.group(1))
+                        progress_callback(line.strip())
 
             #Process stderr
             while not stderr_queue.empty():

--- a/nmap3/utils.py
+++ b/nmap3/utils.py
@@ -188,7 +188,6 @@ def communicate_with_progress(
                     #grab the progress line from stdout and pass to progress_callback
                     match = re.search(r'(\d+(?:\.\d+)?)% done', line)
                     if match:
-                        #progress = float(match.group(1))
                         progress_callback(line.strip())
 
             #Process stderr

--- a/nmap3/utils.py
+++ b/nmap3/utils.py
@@ -27,6 +27,7 @@ import functools
 import threading
 import queue
 import re
+from typing import Optional, Callable
 
 from nmap3.exceptions import NmapNotInstalledError
 
@@ -107,7 +108,7 @@ def nmap_is_installed_async():
 def communicate_with_progress(
     sub_proc: subprocess.Popen,
     timeout: int = None,
-    progress_callback: callable[[float], None] = None
+    progress_callback: Optional[Callable[[float], None]] = None
 ) -> tuple[str, str]:
     """
     Reads stdout and stderr from a subprocess, optionally reporting progress.
@@ -183,6 +184,3 @@ def communicate_with_progress(
         output = f.read()
 
     return output, errs
-
-
-communicate_with_progress()

--- a/nmap3/utils.py
+++ b/nmap3/utils.py
@@ -104,7 +104,44 @@ def nmap_is_installed_async():
         return wrapped
     return  wrapper 
 
-def communicate_with_progress(sub_proc, timeout=None, progress_callback=None):
+def communicate_with_progress(
+    sub_proc: subprocess.Popen,
+    timeout: int = None,
+    progress_callback: callable[[float], None] = None
+) -> tuple[str, str]:
+    """
+    Reads stdout and stderr from a subprocess, optionally reporting progress.
+
+    Parameters
+    ----------
+    sub_proc : subprocess.Popen
+        The subprocess object to communicate with.
+    timeout : int | None, optional
+        Timeout in seconds for the subprocess. If None, waits until finished.
+    progress_callback : Callable[[float], None] | None, optional
+        A callback function that is called with the current scan progress
+        as a float between 0.0 and 100.0. Called whenever a line
+        matching "<number>% done" is read from stdout.
+
+    Returns
+    -------
+    Tuple[str, str]
+        A tuple containing the full stdout output and stderr output.
+
+    Example
+    -------
+    def my_progress(progress: float):
+        print(f"Progress: {progress:.2f}%")
+
+    import subprocess
+
+    proc = subprocess.Popen(["/usr/bin/nmap", "-oX", "-", "example.com"],
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            text=True)
+    
+    output, errs = communicate_with_progress(proc, timeout=60, progress_callback=my_progress)
+    """
     stdout_queue = queue.Queue()
     stderr_queue = queue.Queue()
 
@@ -146,3 +183,6 @@ def communicate_with_progress(sub_proc, timeout=None, progress_callback=None):
         output = f.read()
 
     return output, errs
+
+
+communicate_with_progress()


### PR DESCRIPTION
This time the implementation is cleaner, doesn't have the terminal cleanup code, and is thread safe.

Summary:
Added support for real-time progress reporting in Nmap scans via a progress_callback parameter.

Motivation:
- Provide real-time feedback during long-running scans.
- Preserve compatibility with XML parsing.

Usage Example:
```
def my_progress_callback(progress: str):
    print(progress)

nmap = Nmap()
nmap.scan_top_ports(progress_callback=my_progress_callback)
```

Changes:
- Introduced progress_callback parameter to run_command, scan_command and nmap scan functions.
  - Callback receives a string representing information about the progress of the scan.
- Captures progress from Nmap's stdout using the "--stats-every 1s" flag.
- Switched XML output handling to temporary files created with tempfile module since stdout is used for progress information.
- XML output from nmap is still captured from stdout if the progress_callback function is not provided just as before.

Testing:
Code was tested with file: 
[test.py](https://github.com/user-attachments/files/22033142/test.py)
